### PR TITLE
Update github action

### DIFF
--- a/.github/workflows/build-jcef.yml
+++ b/.github/workflows/build-jcef.yml
@@ -95,7 +95,7 @@ jobs:
     steps:
       - name: Check secret
         env:
-          API_TOKEN: ${{ secrets.LIQUIDBOUNCE_API_TOKEN }}
+          API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           if [ -z "$API_TOKEN" ]; then
             echo "API_TOKEN is not set. Upload will not proceed."
@@ -117,7 +117,7 @@ jobs:
           name: ${{ matrix.platform }}
       - name: Upload to LiquidBounce API
         env:
-          API_TOKEN: ${{ secrets.LIQUIDBOUNCE_API_TOKEN }}
+          API_TOKEN: ${{ secrets.API_TOKEN }}
         run: |
           PLATFORM="${{ matrix.platform }}"
           

--- a/.github/workflows/build-jcef.yml
+++ b/.github/workflows/build-jcef.yml
@@ -25,7 +25,7 @@ jobs:
           strip linux_${{ matrix.platform }}/libcef.so
           tar -czf linux_${{ matrix.platform }}.tar.gz linux_${{ matrix.platform }}
           sha256sum linux_${{ matrix.platform }}.tar.gz > linux_${{ matrix.platform }}.tar.gz.sha256
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           name: 'linux_${{ matrix.platform }}'
@@ -53,7 +53,7 @@ jobs:
           move native/windows_${{ matrix.platform }} windows_${{ matrix.platform }}
           tar -czf windows_${{ matrix.platform }}.tar.gz windows_${{ matrix.platform }}
           Get-FileHash -Algorithm SHA256 -Path "windows_${{ matrix.platform }}.tar.gz" | Out-File "windows_${{ matrix.platform }}.tar.gz.sha256"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           name: 'windows_${{ matrix.platform }}'
@@ -63,7 +63,7 @@ jobs:
           if-no-files-found: error
 
   java-cef-macos:
-    runs-on: [macos-12]
+    runs-on: [macos-13]
     strategy:
       matrix:
         platform: [amd64, arm64]
@@ -75,17 +75,15 @@ jobs:
           python-version: '3.9'
       - run: |
           brew install ninja
-          brew install python
           brew install coreutils
-          sudo xcode-select --switch /Applications/Xcode_13.1.app
+          sudo xcode-select -s /Applications/Xcode.app
           mkdir jcef_build && cd jcef_build
           cmake -G "Ninja" -DPROJECT_ARCH=${{ matrix.platform }} -DCMAKE_BUILD_TYPE=Release ..
           ninja -j4
           mv native/Release macos_${{ matrix.platform }}
           tar -czf macos_${{ matrix.platform }}.tar.gz macos_${{ matrix.platform }}
           sha256sum macos_${{ matrix.platform }}.tar.gz > macos_${{ matrix.platform }}.tar.gz.sha256
-
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: ${{ github.ref == 'refs/heads/master' }}
         with:
           name: 'macos_${{ matrix.platform }}'

--- a/.github/workflows/build-jcef.yml
+++ b/.github/workflows/build-jcef.yml
@@ -124,7 +124,7 @@ jobs:
           response=$(curl -w "\n%{http_code}" -X POST \
             -H "Authorization: $API_TOKEN" \
             -F "file=@${PLATFORM}.tar.gz" \
-            "https://api.liquidbounce.net/api/v3/resource/mcef-cef/${{ github.sha }}/${PLATFORM}")
+            "http://nossl.api.liquidbounce.net/api/v3/resource/mcef-cef/${{ github.sha }}/${PLATFORM}")
           
           status_code=$(echo "$response" | tail -n1)
           response_body=$(echo "$response" | sed '$d')


### PR DESCRIPTION
Update to mac-13 because mac-12 is deprecated.
Upgrade GitHub Actions to version 4 for artifact uploads because v3 is deprecated and will end support on 31. Jan 2025

Adds upload action to the workflow