### PR TITLE
feat: accelerated paint

### DIFF
--- a/java/org/cef/CefBrowserSettings.java
+++ b/java/org/cef/CefBrowserSettings.java
@@ -20,12 +20,29 @@ public class CefBrowserSettings {
      */
     public int windowless_frame_rate = 0;
 
+    /**
+     * Set to true to enable shared texture rendering. When enabled, the browser
+     * will render to a shared texture that can be accessed by the host application
+     * for hardware-accelerated compositing. This is supported on Windows via D3D11,
+     * macOS via Metal/OpenGL, and Linux via native buffers.
+     */
+    public boolean shared_texture_enabled = false;
+
+    /**
+     * Set to true to enable external begin frame scheduling. When enabled, the
+     * client must call CefBrowserHost::SendExternalBeginFrame to trigger frame
+     * rendering at the specified frame rate.
+     */
+    public boolean external_begin_frame_enabled = false;
+
     public CefBrowserSettings() {}
 
     @Override
     public CefBrowserSettings clone() {
         CefBrowserSettings tmp = new CefBrowserSettings();
         tmp.windowless_frame_rate = windowless_frame_rate;
+        tmp.shared_texture_enabled = shared_texture_enabled;
+        tmp.external_begin_frame_enabled = external_begin_frame_enabled;
         return tmp;
     }
 }

--- a/java/org/cef/CefClient.java
+++ b/java/org/cef/CefClient.java
@@ -87,7 +87,7 @@ public class CefClient extends CefClientHandler
     }
 
     public CefBrowser createBrowser(String url, boolean isTransparent,
-            CefRequestContext context, CefBrowserSettings settings) {
+                                    CefRequestContext context, CefBrowserSettings settings) {
         if (isDisposed_)
             throw new IllegalStateException("Can't create browser. CefClient is disposed");
         return CefBrowserFactory.create(
@@ -122,7 +122,7 @@ public class CefClient extends CefClientHandler
     protected CefDisplayHandler getDisplayHandler() {
         return this;
     }
-    
+
     @Override
     protected CefAudioHandler getAudioHandler() {
         return this;
@@ -230,7 +230,7 @@ public class CefClient extends CefClientHandler
     @Override
     public boolean onFileDialog(CefBrowser browser, FileDialogMode mode, String title,
                                 String defaultFilePath, Vector<String> acceptFilters, Vector<String> acceptExtensions,
-            Vector<String> acceptDescriptions, CefFileDialogCallback callback) {
+                                Vector<String> acceptDescriptions, CefFileDialogCallback callback) {
         if (dialogHandler_ != null && browser != null) {
             return dialogHandler_.onFileDialog(browser, mode, title, defaultFilePath, acceptFilters,
                     acceptExtensions, acceptDescriptions, callback);
@@ -322,7 +322,7 @@ public class CefClient extends CefClientHandler
 
     @Override
     public boolean onBeforeDownload(CefBrowser browser, CefDownloadItem downloadItem,
-                                 String suggestedName, CefBeforeDownloadCallback callback) {
+                                    String suggestedName, CefBeforeDownloadCallback callback) {
         if (downloadHandler_ != null && browser != null)
             return downloadHandler_.onBeforeDownload(
                     browser, downloadItem, suggestedName, callback);
@@ -694,6 +694,15 @@ public class CefClient extends CefClientHandler
     }
 
     @Override
+    public void onAcceleratedPaint(CefBrowser browser, boolean popup, Rectangle[] dirtyRects, CefAcceleratedPaintInfo info) {
+        if (browser == null) return;
+
+        CefRenderHandler realHandler = browser.getRenderHandler();
+        if (realHandler != null)
+            realHandler.onAcceleratedPaint(browser, popup, dirtyRects, info);
+    }
+
+    @Override
     public void addOnPaintListener(Consumer<CefPaintEvent> listener) {}
 
     @Override
@@ -701,6 +710,15 @@ public class CefClient extends CefClientHandler
 
     @Override
     public void removeOnPaintListener(Consumer<CefPaintEvent> listener) {}
+
+    @Override
+    public void addOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener) {}
+
+    @Override
+    public void setOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener) {}
+
+    @Override
+    public void removeOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener) {}
 
     @Override
     public boolean startDragging(CefBrowser browser, CefDragData dragData, int mask, int x, int y) {
@@ -808,39 +826,39 @@ public class CefClient extends CefClientHandler
     public boolean getScreenInfo(CefBrowser arg0, CefScreenInfo arg1) {
         return false;
     }
-    
+
     // CefAudioHandler
-    
+
     public CefClient addAudioHandler(CefAudioHandler handler) {
         if (audioHandler_ == null) audioHandler_ = handler;
         return this;
     }
-    
+
     public void removeAudioHandler() {
         audioHandler_ = null;
     }
-    
+
     @Override
     public boolean getAudioParameters(CefBrowser browser, CefAudioParameters params) {
         if (audioHandler_ != null) return audioHandler_.getAudioParameters(browser, params);
         return false;
     }
-    
+
     @Override
     public void onAudioStreamStarted(CefBrowser browser, CefAudioParameters params, int channels) {
         if (audioHandler_ != null) audioHandler_.onAudioStreamStarted(browser, params, channels);
     }
-    
+
     @Override
     public void onAudioStreamPacket(CefBrowser browser, DataPointer data, int frames, long pts) {
         if (audioHandler_ != null) audioHandler_.onAudioStreamPacket(browser, data, frames, pts);
     }
-    
+
     @Override
     public void onAudioStreamStopped(CefBrowser browser) {
         if (audioHandler_ != null) audioHandler_.onAudioStreamStopped(browser);
     }
-    
+
     @Override
     public void onAudioStreamError(CefBrowser browser, String text) {
         if (audioHandler_ != null) audioHandler_.onAudioStreamError(browser, text);

--- a/java/org/cef/browser/CefAcceleratedPaintEvent.java
+++ b/java/org/cef/browser/CefAcceleratedPaintEvent.java
@@ -1,0 +1,48 @@
+// Copyright (c) 2024 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+package org.cef.browser;
+
+import org.cef.handler.CefAcceleratedPaintInfo;
+
+import java.awt.*;
+
+public class CefAcceleratedPaintEvent {
+    private final CefBrowser browser;
+    private final boolean popup;
+    private final Rectangle[] dirtyRects;
+    private final CefAcceleratedPaintInfo acceleratedPaintInfo;
+
+    public CefAcceleratedPaintEvent(CefBrowser browser, boolean popup, Rectangle[] dirtyRects,
+            CefAcceleratedPaintInfo acceleratedPaintInfo) {
+        this.browser = browser;
+        this.popup = popup;
+        this.dirtyRects = dirtyRects;
+        this.acceleratedPaintInfo = acceleratedPaintInfo;
+    }
+
+    public CefBrowser getBrowser() {
+        return browser;
+    }
+
+    public boolean getPopup() {
+        return popup;
+    }
+
+    public Rectangle[] getDirtyRects() {
+        return dirtyRects;
+    }
+
+    public CefAcceleratedPaintInfo getAcceleratedPaintInfo() {
+        return acceleratedPaintInfo;
+    }
+
+    public int getWidth() {
+        return acceleratedPaintInfo.width;
+    }
+
+    public int getHeight() {
+        return acceleratedPaintInfo.height;
+    }
+}

--- a/java/org/cef/browser/CefBrowser.java
+++ b/java/org/cef/browser/CefBrowser.java
@@ -399,6 +399,15 @@ public interface CefBrowser {
     public void setWindowlessFrameRate(int frameRate);
 
     /**
+     * Send an external begin frame to trigger frame rendering when external begin frame
+     * scheduling is enabled. This method should be called at the desired frame rate when
+     * CefBrowserSettings.external_begin_frame_enabled is set to true.
+     *
+     * @throws UnsupportedOperationException if not supported
+     */
+    public void sendExternalBeginFrame();
+
+    /**
      * Returns the maximum rate in frames per second (fps) that {@code CefRenderHandler::onPaint}
      * will be called for a windowless browser. The actual fps may be lower if the browser cannot
      * generate frames at the requested rate. The minimum value is 1, and the maximum value is 60

--- a/java/org/cef/browser/CefBrowserOsr.java
+++ b/java/org/cef/browser/CefBrowserOsr.java
@@ -9,7 +9,9 @@ import org.cef.CefClient;
 import org.cef.callback.CefDragData;
 import org.cef.handler.CefRenderHandler;
 import org.cef.handler.CefScreenInfo;
+import org.cef.handler.CefAcceleratedPaintInfo;
 
+import javax.swing.*;
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.nio.ByteBuffer;
@@ -23,169 +25,199 @@ import java.util.function.Consumer;
  * CefBrowser instance, please use CefBrowserFactory.
  */
 public class CefBrowserOsr extends CefBrowser_N implements CefRenderHandler {
-  private boolean justCreated_ = false;
-  protected Rectangle browser_rect_ = new Rectangle(0, 0, 1, 1); // Work around CEF issue #1437.
-  private Point screenPoint_ = new Point(0, 0);
-  private double scaleFactor_ = 1.0;
-  private int depth = 32;
-  private int depth_per_component = 8;
-  private boolean isTransparent_;
+    private boolean justCreated_ = false;
+    protected Rectangle browser_rect_ = new Rectangle(0, 0, 1, 1); // Work around CEF issue #1437.
+    private Point screenPoint_ = new Point(0, 0);
+    private double scaleFactor_ = 1.0;
+    private int depth = 32;
+    private int depth_per_component = 8;
+    private boolean isTransparent_;
 
-  private CopyOnWriteArrayList<Consumer<CefPaintEvent>> onPaintListeners = new CopyOnWriteArrayList<>();
+    private CopyOnWriteArrayList<Consumer<CefPaintEvent>> onPaintListeners = new CopyOnWriteArrayList<>();
 
-  protected CefBrowserOsr(CefClient client, String url, boolean transparent, CefRequestContext context,
-      CefBrowserSettings settings) {
-    this(client, url, transparent, context, null, null, settings);
-  }
+    private CopyOnWriteArrayList<Consumer<CefAcceleratedPaintEvent>> onAcceleratedPaintListeners =
+            new CopyOnWriteArrayList<>();
 
-  private CefBrowserOsr(CefClient client, String url, boolean transparent,
-      CefRequestContext context, CefBrowserOsr parent, Point inspectAt,
-      CefBrowserSettings settings) {
-    super(client, url, context, parent, inspectAt, settings);
-    isTransparent_ = transparent;
-  }
+    protected CefBrowserOsr(CefClient client, String url, boolean transparent, CefRequestContext context,
+                            CefBrowserSettings settings) {
+        this(client, url, transparent, context, null, null, settings);
+    }
 
-  @Override
-  public void createImmediately() {
-    justCreated_ = true;
-    // Create the browser immediately.
-    createBrowserIfRequired(false);
-  }
+    private CefBrowserOsr(CefClient client, String url, boolean transparent,
+                          CefRequestContext context, CefBrowserOsr parent, Point inspectAt,
+                          CefBrowserSettings settings) {
+        super(client, url, context, parent, inspectAt, settings);
+        isTransparent_ = transparent;
+    }
 
-  @Override
-  public CefRenderHandler getRenderHandler() {
-    return this;
-  }
+    @Override
+    public void createImmediately() {
+        justCreated_ = true;
+        // Create the browser immediately.
+        createBrowserIfRequired(false);
+    }
 
-  @Override
-  protected CefBrowser_N createDevToolsBrowser(CefClient client, String url,
-      CefRequestContext context, CefBrowser_N parent, Point inspectAt) {
-    return null;
-  }
+    @Override
+    public CefRenderHandler getRenderHandler() {
+        return this;
+    }
 
-  @Override
-  public Rectangle getViewRect(CefBrowser browser) {
-    return browser_rect_;
-  }
+    @Override
+    protected CefBrowser_N createDevToolsBrowser(CefClient client, String url,
+                                                 CefRequestContext context, CefBrowser_N parent, Point inspectAt) {
+        return null;
+    }
 
-  @Override
-  public Point getScreenPoint(CefBrowser browser, Point viewPoint) {
-    Point screenPoint = new Point(screenPoint_);
-    screenPoint.translate(viewPoint.x, viewPoint.y);
-    return screenPoint;
-  }
+    @Override
+    public Rectangle getViewRect(CefBrowser browser) {
+        return browser_rect_;
+    }
 
-  @Override
-  public void onPopupShow(CefBrowser browser, boolean show) {
-  }
+    @Override
+    public Point getScreenPoint(CefBrowser browser, Point viewPoint) {
+        Point screenPoint = new Point(screenPoint_);
+        screenPoint.translate(viewPoint.x, viewPoint.y);
+        return screenPoint;
+    }
+
+    @Override
+    public void onPopupShow(CefBrowser browser, boolean show) {
+    }
 
     @Override
     public void onPopupSize(CefBrowser browser, Rectangle size) {
     }
 
-  @Override
-  public void addOnPaintListener(Consumer<CefPaintEvent> listener) {
-    onPaintListeners.add(listener);
-  }
-
-  @Override
-  public void setOnPaintListener(Consumer<CefPaintEvent> listener) {
-    onPaintListeners.clear();
-    onPaintListeners.add(listener);
-  }
-
-  @Override
-  public void removeOnPaintListener(Consumer<CefPaintEvent> listener) {
-    onPaintListeners.remove(listener);
-  }
-
-  @Override
-  public void onPaint(CefBrowser browser, boolean popup, Rectangle[] dirtyRects, ByteBuffer buffer, int width,
-      int height) {
-    if (!onPaintListeners.isEmpty()) {
-      CefPaintEvent paintEvent = new CefPaintEvent(browser, popup, dirtyRects, buffer, width, height);
-      for (Consumer<CefPaintEvent> l : onPaintListeners) {
-        l.accept(paintEvent);
-      }
+    @Override
+    public void addOnPaintListener(Consumer<CefPaintEvent> listener) {
+        onPaintListeners.add(listener);
     }
-  }
 
-  @Override
-  public boolean onCursorChange(CefBrowser browser, final int cursorType) {
-    return true;
-  }
-
-  // private static final class SyntheticDragGestureRecognizer extends
-  // DragGestureRecognizer {
-  // public SyntheticDragGestureRecognizer(Component c, int action, MouseEvent
-  // triggerEvent) {
-  // super(new DragSource(), c, action);
-  // appendEvent(triggerEvent);
-  // }
-
-  // protected void registerListeners() {}
-
-  // protected void unregisterListeners() {}
-  // };
-
-  // private static int getDndAction(int mask) {
-  // // Default to copy if multiple operations are specified.
-  // int action = DnDConstants.ACTION_NONE;
-  // if ((mask & CefDragData.DragOperations.DRAG_OPERATION_COPY)
-  // == CefDragData.DragOperations.DRAG_OPERATION_COPY) {
-  // action = DnDConstants.ACTION_COPY;
-  // } else if ((mask & CefDragData.DragOperations.DRAG_OPERATION_MOVE)
-  // == CefDragData.DragOperations.DRAG_OPERATION_MOVE) {
-  // action = DnDConstants.ACTION_MOVE;
-  // } else if ((mask & CefDragData.DragOperations.DRAG_OPERATION_LINK)
-  // == CefDragData.DragOperations.DRAG_OPERATION_LINK) {
-  // action = DnDConstants.ACTION_LINK;
-  // }
-  // return action;
-  // }
-
-  @Override
-  public boolean startDragging(CefBrowser browser, CefDragData dragData, int mask, int x, int y) {
-    return true;
-  }
-
-  @Override
-  public void updateDragCursor(CefBrowser browser, int operation) {
-  }
-
-  private void createBrowserIfRequired(boolean hasParent) {
-    long windowHandle = 0;
-    if (getNativeRef("CefBrowser") == 0) {
-      if (getParentBrowser() != null) {
-        createDevTools(getParentBrowser(), getClient(), windowHandle, true, isTransparent_,
-            getInspectAt());
-      } else {
-        createBrowser(getClient(), windowHandle, getUrl(), true, isTransparent_,
-            getRequestContext());
-      }
-    } else if (hasParent && justCreated_) {
-      notifyAfterParentChanged();
-      setFocus(true);
-      justCreated_ = false;
+    @Override
+    public void setOnPaintListener(Consumer<CefPaintEvent> listener) {
+        onPaintListeners.clear();
+        onPaintListeners.add(listener);
     }
-  }
 
-  private void notifyAfterParentChanged() {
-    // With OSR there is no native window to reparent but we still need to send the
-    // notification.
-    getClient().onAfterParentChanged(this);
-  }
+    @Override
+    public void removeOnPaintListener(Consumer<CefPaintEvent> listener) {
+        onPaintListeners.remove(listener);
+    }
 
-  @Override
-  public boolean getScreenInfo(CefBrowser browser, CefScreenInfo screenInfo) {
-    screenInfo.Set(scaleFactor_, depth, depth_per_component, false, browser_rect_.getBounds(),
-        browser_rect_.getBounds());
+    @Override
+    public void addOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener) {
+        onAcceleratedPaintListeners.add(listener);
+    }
 
-    return true;
-  }
+    @Override
+    public void setOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener) {
+        onAcceleratedPaintListeners.clear();
+        onAcceleratedPaintListeners.add(listener);
+    }
 
-  @Override
-  public CompletableFuture<BufferedImage> createScreenshot(boolean nativeResolution) {
-    return null;
-  }
+    @Override
+    public void removeOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener) {
+        onAcceleratedPaintListeners.remove(listener);
+    }
+
+    @Override
+    public void onPaint(CefBrowser browser, boolean popup, Rectangle[] dirtyRects, ByteBuffer buffer, int width,
+                        int height) {
+        if (!onPaintListeners.isEmpty()) {
+            CefPaintEvent paintEvent = new CefPaintEvent(browser, popup, dirtyRects, buffer, width, height);
+            for (Consumer<CefPaintEvent> l : onPaintListeners) {
+                l.accept(paintEvent);
+            }
+        }
+    }
+
+    @Override
+    public void onAcceleratedPaint(CefBrowser browser, boolean popup, Rectangle[] dirtyRects, CefAcceleratedPaintInfo info) {
+        if (!onAcceleratedPaintListeners.isEmpty()) {
+            CefAcceleratedPaintEvent paintEvent =
+                    new CefAcceleratedPaintEvent(browser, popup, dirtyRects, info);
+            for (Consumer<CefAcceleratedPaintEvent> l : onAcceleratedPaintListeners) {
+                l.accept(paintEvent);
+            }
+        }
+    }
+
+    @Override
+    public boolean onCursorChange(CefBrowser browser, final int cursorType) {
+        return true;
+    }
+
+    // private static final class SyntheticDragGestureRecognizer extends
+    // DragGestureRecognizer {
+    // public SyntheticDragGestureRecognizer(Component c, int action, MouseEvent
+    // triggerEvent) {
+    // super(new DragSource(), c, action);
+    // appendEvent(triggerEvent);
+    // }
+
+    // protected void registerListeners() {}
+
+    // protected void unregisterListeners() {}
+    // };
+
+    // private static int getDndAction(int mask) {
+    // // Default to copy if multiple operations are specified.
+    // int action = DnDConstants.ACTION_NONE;
+    // if ((mask & CefDragData.DragOperations.DRAG_OPERATION_COPY)
+    // == CefDragData.DragOperations.DRAG_OPERATION_COPY) {
+    // action = DnDConstants.ACTION_COPY;
+    // } else if ((mask & CefDragData.DragOperations.DRAG_OPERATION_MOVE)
+    // == CefDragData.DragOperations.DRAG_OPERATION_MOVE) {
+    // action = DnDConstants.ACTION_MOVE;
+    // } else if ((mask & CefDragData.DragOperations.DRAG_OPERATION_LINK)
+    // == CefDragData.DragOperations.DRAG_OPERATION_LINK) {
+    // action = DnDConstants.ACTION_LINK;
+    // }
+    // return action;
+    // }
+
+    @Override
+    public boolean startDragging(CefBrowser browser, CefDragData dragData, int mask, int x, int y) {
+        return true;
+    }
+
+    @Override
+    public void updateDragCursor(CefBrowser browser, int operation) {
+    }
+
+    private void createBrowserIfRequired(boolean hasParent) {
+        long windowHandle = 0;
+        if (getNativeRef("CefBrowser") == 0) {
+            if (getParentBrowser() != null) {
+                createDevTools(getParentBrowser(), getClient(), windowHandle, true, isTransparent_,
+                        getInspectAt());
+            } else {
+                createBrowser(getClient(), windowHandle, getUrl(), true, isTransparent_,
+                        getRequestContext());
+            }
+        } else if (hasParent && justCreated_) {
+            notifyAfterParentChanged();
+            setFocus(true);
+            justCreated_ = false;
+        }
+    }
+
+    private void notifyAfterParentChanged() {
+        // With OSR there is no native window to reparent but we still need to send the
+        // notification.
+        getClient().onAfterParentChanged(this);
+    }
+
+    @Override
+    public boolean getScreenInfo(CefBrowser browser, CefScreenInfo screenInfo) {
+        screenInfo.Set(scaleFactor_, depth, depth_per_component, false, browser_rect_.getBounds(),
+                browser_rect_.getBounds());
+
+        return true;
+    }
+
+    @Override
+    public CompletableFuture<BufferedImage> createScreenshot(boolean nativeResolution) {
+        return null;
+    }
 }

--- a/java/org/cef/browser/CefBrowser_N.java
+++ b/java/org/cef/browser/CefBrowser_N.java
@@ -772,6 +772,14 @@ public abstract class CefBrowser_N extends CefNativeAdapter implements CefBrowse
         }
     }
 
+    public void sendExternalBeginFrame() {
+        try {
+            N_SendExternalBeginFrame();
+        } catch (UnsatisfiedLinkError ule) {
+            ule.printStackTrace();
+        }
+    }
+
     public CompletableFuture<Integer> getWindowlessFrameRate() {
         final CompletableFuture<Integer> future = new CompletableFuture<>();
         try {
@@ -854,5 +862,6 @@ public abstract class CefBrowser_N extends CefNativeAdapter implements CefBrowse
     private final native void N_UpdateUI(Rectangle contentRect, Rectangle browserRect);
     private final native void N_NotifyMoveOrResizeStarted();
     private final native void N_SetWindowlessFrameRate(int frameRate);
+    private final native void N_SendExternalBeginFrame();
     private final native void N_GetWindowlessFrameRate(IntCallback frameRateCallback);
 }

--- a/java/org/cef/handler/CefAcceleratedPaintInfo.java
+++ b/java/org/cef/handler/CefAcceleratedPaintInfo.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2024 The Chromium Embedded Framework Authors. All rights
+// reserved. Use of this source code is governed by a BSD-style license that
+// can be found in the LICENSE file.
+
+package org.cef.handler;
+
+/**
+ * Structure representing shared texture info for accelerated painting.
+ */
+public class CefAcceleratedPaintInfo {
+    /**
+     * Shared texture handle. The meaning depends on the platform:
+     * - Windows: HANDLE to a texture that can be opened with D3D11 OpenSharedResource
+     * - macOS: IOSurface pointer that can be opened with Metal or OpenGL
+     * - Linux: Contains several planes, each with an fd to the underlying system native buffer
+     */
+    public long shared_texture_handle = 0;
+    
+    /**
+     * Format of the shared texture.
+     */
+    public int format = 0;
+    
+    /**
+     * Size information for the shared texture.
+     */
+    public int width = 0;
+    public int height = 0;
+    
+    public CefAcceleratedPaintInfo() {}
+    
+    public CefAcceleratedPaintInfo(long shared_texture_handle, int format, int width, int height) {
+        this.shared_texture_handle = shared_texture_handle;
+        this.format = format;
+        this.width = width;
+        this.height = height;
+    }
+    
+    @Override
+    public CefAcceleratedPaintInfo clone() {
+        return new CefAcceleratedPaintInfo(shared_texture_handle, format, width, height);
+    }
+}

--- a/java/org/cef/handler/CefRenderHandler.java
+++ b/java/org/cef/handler/CefRenderHandler.java
@@ -4,6 +4,7 @@
 
 package org.cef.handler;
 
+import org.cef.browser.CefAcceleratedPaintEvent;
 import org.cef.browser.CefBrowser;
 import org.cef.browser.CefPaintEvent;
 import org.cef.callback.CefDragData;
@@ -66,6 +67,35 @@ public interface CefRenderHandler {
      */
     public void onPaint(CefBrowser browser, boolean popup, Rectangle[] dirtyRects,
             ByteBuffer buffer, int width, int height);
+
+    /**
+     * Called when an element has been rendered to the shared texture handle.
+     * This method is only called when CefWindowInfo::shared_texture_enabled is set to true.
+     * @param browser The browser generating the event.
+     * @param popup True if painting a popup window.
+     * @param dirtyRects Array of dirty regions.
+     * @param info Contains the shared handle and texture information.
+     */
+    public void onAcceleratedPaint(CefBrowser browser, boolean popup, Rectangle[] dirtyRects,
+            CefAcceleratedPaintInfo info);
+
+    /**
+     * Add provided listener for accelerated paint events.
+     * @param listener Code that gets executed after a frame was rendered with accelerated painting.
+     */
+    public void addOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener);
+
+    /**
+     * Remove existing accelerated paint listeners and replace with provided listener.
+     * @param listener Code that gets executed after a frame was rendered with accelerated painting.
+     */
+    public void setOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener);
+
+    /**
+     * Remove provided accelerated paint listener.
+     * @param listener Code that gets executed after a frame was rendered with accelerated painting.
+     */
+    public void removeOnAcceleratedPaintListener(Consumer<CefAcceleratedPaintEvent> listener);
 
     /**
      * Add provided listener.

--- a/java/org/cef/handler/CefRenderHandlerAdapter.java
+++ b/java/org/cef/handler/CefRenderHandlerAdapter.java
@@ -43,6 +43,10 @@ public abstract class CefRenderHandlerAdapter implements CefRenderHandler {
             ByteBuffer buffer, int width, int height) {}
 
     @Override
+    public void onAcceleratedPaint(CefBrowser browser, boolean popup, Rectangle[] dirtyRects,
+            CefAcceleratedPaintInfo info) {}
+
+    @Override
     public boolean onCursorChange(CefBrowser browser, int cursorType) {
         return false;
     }

--- a/native/CefBrowser_N.cpp
+++ b/native/CefBrowser_N.cpp
@@ -575,7 +575,7 @@ KeyboardCode KeyboardCodeFromXKeysym(unsigned int keysym) {
       return VKEY_OEM_7;
     case XK_ISO_Level5_Shift:
       return VKEY_OEM_8;
-    case XK_Shift_L:
+        case XK_Shift_L:
     case XK_Shift_R:
       return VKEY_SHIFT;
     case XK_Control_L:
@@ -1042,6 +1042,10 @@ void create(std::shared_ptr<JNIObjectsForCreate> objs,
       objs->jbrowserSettings != nullptr) {  // Dev-tools settings are null
     GetJNIFieldInt(env, cefBrowserSettings, objs->jbrowserSettings,
                    "windowless_frame_rate", &settings.windowless_frame_rate);
+    GetJNIFieldBoolean(env, cefBrowserSettings, objs->jbrowserSettings,
+                       "shared_texture_enabled", &windowInfo.shared_texture_enabled);
+    GetJNIFieldBoolean(env, cefBrowserSettings, objs->jbrowserSettings,
+                       "external_begin_frame_enabled", &windowInfo.external_begin_frame_enabled);
   }
 
   CefRefPtr<CefBrowser> browserObj;
@@ -2165,6 +2169,14 @@ Java_org_cef_browser_CefBrowser_1N_N_1SetWindowlessFrameRate(JNIEnv* env,
   CefRefPtr<CefBrowser> browser = JNI_GET_BROWSER_OR_RETURN(env, jbrowser);
   CefRefPtr<CefBrowserHost> host = browser->GetHost();
   host->SetWindowlessFrameRate(frameRate);
+}
+
+JNIEXPORT void JNICALL
+Java_org_cef_browser_CefBrowser_1N_N_1SendExternalBeginFrame(JNIEnv* env,
+                                                              jobject jbrowser) {
+  CefRefPtr<CefBrowser> browser = JNI_GET_BROWSER_OR_RETURN(env, jbrowser);
+  CefRefPtr<CefBrowserHost> host = browser->GetHost();
+  host->SendExternalBeginFrame();
 }
 
 void getWindowlessFrameRate(CefRefPtr<CefBrowserHost> host,

--- a/native/CefBrowser_N.h
+++ b/native/CefBrowser_N.h
@@ -555,6 +555,15 @@ Java_org_cef_browser_CefBrowser_1N_N_1GetWindowlessFrameRate(JNIEnv*,
                                                              jobject,
                                                              jobject);
 
+/*
+ * Class:     org_cef_browser_CefBrowser_N
+ * Method:    N_SendExternalBeginFrame
+ * Signature: ()V
+ */
+JNIEXPORT void JNICALL
+Java_org_cef_browser_CefBrowser_1N_N_1SendExternalBeginFrame(JNIEnv*,
+                                                              jobject);
+
 #ifdef __cplusplus
 }
 #endif

--- a/native/jni_util.cpp
+++ b/native/jni_util.cpp
@@ -894,6 +894,20 @@ bool SetJNIFieldBoolean(JNIEnv* env,
   return false;
 }
 
+bool SetJNIFieldLong(JNIEnv* env,
+                     jclass cls,
+                     jobject obj,
+                     const char* field_name,
+                     jlong value) {
+  jfieldID field = env->GetFieldID(cls, field_name, "J");
+  if (field) {
+    env->SetLongField(obj, field, value);
+    return true;
+  }
+  env->ExceptionClear();
+  return false;
+}
+
 bool GetJNIFieldStaticInt(JNIEnv* env,
                           jclass cls,
                           const char* field_name,

--- a/native/jni_util.h
+++ b/native/jni_util.h
@@ -148,6 +148,11 @@ bool SetJNIFieldBoolean(JNIEnv* env,
                         jobject obj,
                         const char* field_name,
                         int value);
+bool SetJNIFieldLong(JNIEnv* env,
+                     jclass cls,
+                     jobject obj,
+                     const char* field_name,
+                     jlong value);
 
 // Retrieve the static int value stored in the |field_name| field of |cls|.
 bool GetJNIFieldStaticInt(JNIEnv* env,

--- a/native/render_handler.h
+++ b/native/render_handler.h
@@ -40,6 +40,10 @@ class RenderHandler : public CefRenderHandler {
                        const void* buffer,
                        int width,
                        int height) override;
+  virtual void OnAcceleratedPaint(CefRefPtr<CefBrowser> browser,
+                                  PaintElementType type,
+                                  const RectList& dirtyRects,
+                                  const CefAcceleratedPaintInfo& info) override;
   virtual bool StartDragging(CefRefPtr<CefBrowser> browser,
                              CefRefPtr<CefDragData> drag_data,
                              DragOperationsMask allowed_ops,


### PR DESCRIPTION
**CEF supports** hardware-accelerated off-screen rendering by enabling `shared_texture_enabled` via `WindowInfo` and passing `--off-screen-rendering-enabled --shared-texture-enabled` as arguments.
- https://bitbucket.org/chromiumembedded/cef/pull-requests/734
- https://github.com/chromiumembedded/cef/blob/2c411892e273c564dfb6650dcee8fea458849178/include/cef_render_handler.h#L151-L173.

Unfortunately, Java CEF lacks bindings for OnAcceleratedPaint, meaning we cannot make use of this feature. This pull request enables this feature when turning `shared_texture_enabled` to true.

The changes were tested on a forked JCEF version (on CEF 130.1.9) by converting the D3D11 shared texture handle using `ImportMemoryWin32HandleEXT` using [OpenGL's EXT_external_objects_win32](https://registry.khronos.org/OpenGL/extensions/EXT/EXT_external_objects_win32.txt) which is supported by LWJGL3.

![image](https://github.com/user-attachments/assets/3b5c146e-7581-44b6-8fbb-6208b33fe388)

_Ignore the inverted colors. It was still missing the shader for the color conversion._

Fixes https://github.com/chromiumembedded/java-cef/issues/506